### PR TITLE
Bugfix: correct time cmd duration in right prompt

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -61,5 +61,5 @@ function _is_multiplexed
 end
 
 function _convertsecs
- printf "%02d:%02d:%02d\n" (math $argv[1] / 3600) (math (math $argv[1] \% 3600) / 60) (math $argv[1] \% 60)
+  printf "%02d:%02d:%02d\n" (math -s0 $argv[1] / 3600) (math -s0 (math $argv[1] \% 3600) / 60) (math -s0 $argv[1] \% 60)
 end


### PR DESCRIPTION
Bugfix for issue [cmd_duration prints a warning on each command on OSX #11](https://github.com/hasanozgan/theme-lambda/issues/11#issue-506537073)
I added `-s0` parameter after `math` command in `_convertsecs` function.
It cuts float number to an integer before passing a value to `printf "%02d"` function.
