### PR TITLE
Conscise display of $CMD_DURATION in right prompt

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -13,7 +13,7 @@ function fish_right_prompt
   else
     set_color blue
   end
-  printf ' < %s' (_convertsecs (math $cmd_duration / 1000))
+  printf ' (%s)' (__print_duration $cmd_duration)
   set_color 666666
   printf ' < %s' (date +%H:%M:%S)
   set_color normal
@@ -60,6 +60,23 @@ function _is_multiplexed
   echo $multiplexer
 end
 
-function _convertsecs
- printf "%02d:%02d:%02d\n" (math $argv[1] / 3600) (math (math $argv[1] \% 3600) / 60) (math $argv[1] \% 60)
+function __print_duration
+  set -l duration $argv[1]
+ 
+  set -l millis  (math $duration % 1000)
+  set -l seconds (math -s0 $duration / 1000 % 60)
+  set -l minutes (math -s0 $duration / 60000 % 60)
+  set -l hours   (math -s0 $duration / 3600000 % 60)
+ 
+  if test $duration -lt 60000;
+    # Below a minute
+    printf "%d.%03ds\n" $seconds $millis
+  else if test $duration -lt 3600000;
+    # Below a hour
+    printf "%02d:%02d.%03d\n" $minutes $seconds $millis
+  else
+    # Everything else
+    printf "%02d:%02d:%02d.%03d\n" $hours $minutes $seconds $millis
+  end
 end
+


### PR DESCRIPTION
Bugfix for https://github.com/hasanozgan/theme-lambda/issues/11, based on https://github.com/hasanozgan/theme-lambda/issues/11#issuecomment-552119396.

Plus conscise display of duration. See screenshot below
![lamba-right-prompt-duration](https://user-images.githubusercontent.com/4029505/72073856-150e7e80-32f1-11ea-94a1-57cc7c140f53.png)

