### PR TITLE
Use uname -n to get hostname

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -4,7 +4,7 @@ function fish_prompt
 
   # Just calculate these once, to save a few cycles when displaying the prompt
   if not set -q __fish_prompt_hostname
-    set -g __fish_prompt_hostname (hostname|cut -d . -f 1)
+    set -g __fish_prompt_hostname (uname -n|cut -d . -f 1)
   end
   if not set -q __fish_prompt_char
     switch (id -u)


### PR DESCRIPTION
Some distributions don't always have legacy _inetutils_ installed. Instead we can use `uname -n` from _coreutils_ to get hostname.

See also: [uname -n vs hostname](https://unix.stackexchange.com/questions/199698/uname-n-vs-hostname)