### PR TITLE
Fix broken virtualenv prompt on sourcing of activate.fish

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -59,6 +59,10 @@ function fish_prompt
 
   # Line 2
   echo -n $white'╰'
+
+  # Disable virtualenv's default prompt
+  set -g VIRTUAL_ENV_DISABLE_PROMPT true
+
   # support for virtual env name
   if set -q VIRTUAL_ENV
       echo -n "($turquoise"(basename "$VIRTUAL_ENV")"$white)"


### PR DESCRIPTION
Theme's virtualenv prompt was conflicting with virtualenv's default
prompt for fish when virtualenv was manually loaded through
`source virtualenv-path/bin/activate.fish`. Upon loading of the
theme, one would get a prompt that looked like the following:

```sh
(venv) ╭─user at host in ⌁
╰(venv)─λ
```

Fix is to notify virtualenv that prompt has already been set
through environment variable `VIRTUAL_ENV_DISABLE_PROMPT`.