### PR TITLE
prefer `uname -n` to `hostname`

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -16,7 +16,7 @@ function fish_prompt
   end
 
   # Setup colors
-  set -l hostcolor (set_color (hostname | md5sum | cut -f1 -d' ' | tr -d '\n' | tail -c6))
+  set -l hostcolor (set_color (uname -n | md5sum | cut -f1 -d' ' | tr -d '\n' | tail -c6))
   set -l normal (set_color normal)
   set -l white (set_color FFFFFF)
   set -l turquoise (set_color 5fdfff)


### PR DESCRIPTION
Suggestion from @YHNdnzj to improve compatibility