### PR TITLE
Filter out color codes from pane title

### DIFF
--- a/functions/fish_right_prompt.fish
+++ b/functions/fish_right_prompt.fish
@@ -27,6 +27,7 @@ function __tmux_prompt
       set pane (_get_screen_window)
     case tmux
       set pane (_get_tmux_window)
+      set pane (string replace -ra '#\[[bf]g=[^\]]+\]' '' $pane)
    end
 
   set_color 666666


### PR DESCRIPTION
tmux uses a non-ANSI control sequence to set colors in tab names. This filters those control sequences from the right_prompt.